### PR TITLE
Format stat card display data, add daily/weekly offset toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,3 +27,10 @@
   align-items: center;
   padding: 40px;
 }
+
+.toggle-daily {
+  order: -1;
+  align-self: flex-start;
+  margin-bottom: 20px;
+  width: 80px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -44,6 +44,13 @@ const App = () => {
       <Sidebar />
       <section className='display'>
         <Route exact path='/'>
+          <Button
+            className="toggle-daily"
+            onClick={handleToggleSubmit}
+            color={isDaily ? "primary" : "secondary"}
+          >
+              {isDaily ? "Daily" : "Weekly"}
+          </Button>
           <Home current={data[0]} previous={data[offset]} movementType={movementType}/>
         </Route>
         <Route exact path='/daily-cases'>
@@ -58,13 +65,6 @@ const App = () => {
         <Route exact path='/daily-tested'>
           <DailyStats data={data} type='Tested' yAccessor='Tested' />
         </Route>
-        <Button
-          className="toggle-daily"
-          onClick={handleToggleSubmit}
-          color={isDaily ? "primary" : "secondary"}
-        >
-            {isDaily ? "Daily" : "Weekly"}
-        </Button>
       </section>
     </section>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,8 @@ const App = () => {
     let newData = [];
     data.map((attr) => newData.push(...Object.values(attr)));
     let filteredData = newData.filter((attr) => attr.Date !== null);
-    return sortObjectsByDescendingDate(filteredData);
+    let sortedData = sortObjectsByDescendingDate(filteredData);
+    return sortedData;
   };
 
   useEffect(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,10 @@
 import "./App.css";
 import "tabler-react/dist/Tabler.css";
 
-import { Button, Form } from "tabler-react";
 import React, { useEffect, useState } from "react";
 
 import { API_URL } from "./utils/constants";
+import { Button } from "tabler-react";
 import DailyStats from "./components/DailyStats/DailyStats";
 import { Home } from "./components/Home/Home";
 import { Route } from "react-router-dom";

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import "./App.css";
 import "tabler-react/dist/Tabler.css";
 
+import { Button, Form } from "tabler-react";
 import React, { useEffect, useState } from "react";
 
 import { API_URL } from "./utils/constants";
@@ -12,6 +13,10 @@ import { sortObjectsByDescendingDate } from "./utils/utilities";
 
 const App = () => {
   const [data, setData] = useState([]);
+  const [isDaily, setIsDaily] = useState(true);
+  // diffs are weekly if isDaily is false
+  const offset = isDaily ? 1 : 7;
+  const movementType = isDaily ? "daily" : "weekly";
   const cleanData = (data) => {
     let newData = [];
     data.map((attr) => newData.push(...Object.values(attr)));
@@ -30,12 +35,16 @@ const App = () => {
       .catch((err) => console.log(err));
   }, []);
 
+  const handleToggleSubmit = (event) => {
+    setIsDaily(!isDaily);
+  }
+
   return (
     <section className='app'>
       <Sidebar />
       <section className='display'>
         <Route exact path='/'>
-          <Home today={data[0]} yesterday={data[1]} />
+          <Home current={data[0]} previous={data[offset]} movementType={movementType}/>
         </Route>
         <Route exact path='/daily-cases'>
           <DailyStats data={data} type='Cases' yAccessor='Cases' />
@@ -49,6 +58,13 @@ const App = () => {
         <Route exact path='/daily-tested'>
           <DailyStats data={data} type='Tested' yAccessor='Tested' />
         </Route>
+        <Button
+          className="toggle-daily"
+          onClick={handleToggleSubmit}
+          color={isDaily ? "primary" : "secondary"}
+        >
+            {isDaily ? "Daily" : "Weekly"}
+        </Button>
       </section>
     </section>
   );

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,5 +1,5 @@
-import React from "react";
 import { Grid } from "tabler-react";
+import React from "react";
 import { StatsCard } from "./StatsCard";
 
 const GridContainer = (props) => (
@@ -9,18 +9,18 @@ const GridContainer = (props) => (
 );
 
 export const Home = (props) => {
-  const { today, yesterday } = props;
+  const { current, previous, movementType } = props;
 
   return (
     <div>
-      {today && yesterday && (
+      {current && previous && (
         <Grid.Row cards deck>
-          {Object.keys(today).map((key) => (
+          {Object.keys(current).map((key) => (
             <GridContainer>
               <StatsCard
-                movement={today[key] - yesterday[key]}
-                movementType={" daily"}
-                total={today[key]}
+                movement={current[key] - previous[key]}
+                movementType={movementType}
+                total={current[key]}
                 label={key}
               />
             </GridContainer>

--- a/src/components/Home/StatsCard.js
+++ b/src/components/Home/StatsCard.js
@@ -53,11 +53,11 @@ export const StatsCard = (_ref) => {
   const positiveLabels = [
     "population",
     "tested",
+    "test_encounters",
   ]
 
   const negativeLabels = [
     "cases",
-    "test_encounters",
     "deaths",
     "dthcovid19",
     "rate",
@@ -82,7 +82,8 @@ export const StatsCard = (_ref) => {
   const labelAliases = {
     name: "State",
     desc_: "Description",
-    test_encounters: "Test Encounters",
+    tested: "Tested For The First Time",
+    test_encounters: "People Tested",
     deaths: "Deaths Among Cases",
     dthcovid19: "Deaths From C19",
     hosp: "Hospitalizations From C19",

--- a/src/components/Home/StatsCard.js
+++ b/src/components/Home/StatsCard.js
@@ -39,7 +39,7 @@ export const StatsCard = (_ref) => {
   let movementString = "";
   if ( !isNaN(movement) ) {
     movementString = formatter(movement);
-    movementString = "" + (movement > 0 ? "+" : "") + movementString + movementType;
+    movementString = "" + (movement > 0 ? "+" : "") + movementString + " " + movementType;
   }
 
   const neutralLabels = [

--- a/src/components/Home/StatsCard.js
+++ b/src/components/Home/StatsCard.js
@@ -1,5 +1,7 @@
+import { Card, Header, Icon, Text } from "tabler-react";
+import { formatComma, formatDecimal } from "../../utils/utilities";
+
 import React from "react";
-import { Card, Header, Text, Icon } from "tabler-react";
 
 export const StatsCard = (_ref) => {
   var className = _ref.className,
@@ -7,25 +9,107 @@ export const StatsCard = (_ref) => {
     movementType = _ref.movementType,
     total = _ref.total,
     label = _ref.label;
-    
 
-  var movementString = "" + (movement > 0 ? "+" : "") + movement + movementType;
-  var movementColor = !movement ? "yellow" : movement > 0 ? "green" : "red";
+  const labelDatatypes = {
+    cases: "integer",
+    tested: "integer",
+    test_encounters: "integer",
+    deaths: "integer",
+    dthcovid19: "integer",
+    population: "integer",
+    rate: "decimal",
+    hosp: "integer",
+    counties: "integer",
+    outbreaks: "integer",
+  }
+
+  const getFormatter = (label) => {
+    let datatype = labelDatatypes[label.toLowerCase()]
+    if ( datatype === "integer" ) {
+        return formatComma;
+    } else if ( datatype === "decimal" ) {
+        return x => formatDecimal(x, 2);
+    }
+    return x => x;
+  }
+
+  let formatter = getFormatter(label);
+  let totalString = formatter(total);
+
+  let movementString = "";
+  if ( !isNaN(movement) ) {
+    movementString = formatter(movement);
+    movementString = "" + (movement > 0 ? "+" : "") + movementString + movementType;
+  }
+
+  const neutralLabels = [
+    "objectid",
+    "name",
+    "desc_",
+    "date",
+    "counties",
+  ]
+  const hideMovement = neutralLabels.includes(label.toLowerCase());
+
+  const positiveLabels = [
+    "population",
+    "tested",
+  ]
+
+  const negativeLabels = [
+    "cases",
+    "test_encounters",
+    "deaths",
+    "dthcovid19",
+    "rate",
+    "hosp",
+    "outbreaks",
+  ]
+
+  const getMovementColor = (label, movement) => {
+    label = label.toLowerCase();
+    if (hideMovement || isNaN(movement)) {
+      return "white";
+    } else if ( positiveLabels.includes(label) ) {
+      return !movement ? "yellow" : movement > 0 ? "green": "red";
+    } else if ( negativeLabels.includes(label) ) {
+      return !movement ? "yellow" : movement > 0 ? "red": "green";
+    }
+    return "yellow";
+  }
+  let movementColor = getMovementColor(label, movement);
+
+  const labelAliases = {
+    name: "State",
+    desc_: "Description",
+    test_encounters: "Test Encounters",
+    dthcovid19: "Deaths From Covid 19",
+    hosp: "Hospitalizations",
+  }
+
+  const getLabelAlias = (label) => {
+    let labelLower = label.toLowerCase();
+    if (labelLower in labelAliases) {
+      return labelAliases[labelLower];
+    }
+    return label
+  }
+  let labelAlias = getLabelAlias(label);
 
   return (
     <Card className={className}>
-      <Card.Body className='p-3 text-center'>
-        <Text color={movementColor} className='text-right'>
-          {movementString}{" "}
-          <Icon
-            name={
-              !movement ? "minus" : movement > 0 ? "chevron-up" : "chevron-down"
-            }
-          />
-        </Text>
-        <Header className='m-0'>{total}</Header>
+      <Card.Body className='p-5 text-center'>
+          <Text color={movementColor} className='text-right'>
+            {hideMovement ? "" : movementString + " "}
+            <Icon
+              name={
+                (!movement || hideMovement) ? "minus" : movement > 0 ? "chevron-up" : "chevron-down"
+              }
+            />
+          </Text>
+        <Header className='m-0'>{totalString}</Header>
         <Text color='muted' className='mb-4'>
-          {label}
+          {labelAlias}
         </Text>
       </Card.Body>
     </Card>

--- a/src/components/Home/StatsCard.js
+++ b/src/components/Home/StatsCard.js
@@ -47,7 +47,6 @@ export const StatsCard = (_ref) => {
     "name",
     "desc_",
     "date",
-    "counties",
   ]
   const hideMovement = neutralLabels.includes(label.toLowerCase());
 
@@ -64,6 +63,7 @@ export const StatsCard = (_ref) => {
     "rate",
     "hosp",
     "outbreaks",
+    "counties",
   ]
 
   const getMovementColor = (label, movement) => {
@@ -83,8 +83,11 @@ export const StatsCard = (_ref) => {
     name: "State",
     desc_: "Description",
     test_encounters: "Test Encounters",
-    dthcovid19: "Deaths From Covid 19",
-    hosp: "Hospitalizations",
+    deaths: "Deaths Among Cases",
+    dthcovid19: "Deaths From C19",
+    hosp: "Hospitalizations From C19",
+    counties: "Counties Reporting Cases",
+    rate: "Infection Rate Per 100,000"
   }
 
   const getLabelAlias = (label) => {

--- a/src/utils/utilities.js
+++ b/src/utils/utilities.js
@@ -6,6 +6,15 @@ export function formatComma(num){
     return num;
 }
 
+export function formatDecimal(num, decimalPlaces) {
+    num = num.toString();
+    let [integerPart, fractionalPart] = num.split('.');
+    if ( fractionalPart.length > decimalPlaces ) {
+        fractionalPart = fractionalPart.substring(0, decimalPlaces);
+    }
+    return formatComma(integerPart) + "." + fractionalPart;
+}
+
 export function formatDate(date){
     const monthArray = ["January", "February", "March", "April", "May", "June", "July","August", "September", "October", "November", "December"];
     const dateArray = date.split('/');
@@ -40,3 +49,4 @@ export function sortObjectsByDescendingDate(objects, parseDate) {
     objectsCopy.sort((a, b) => parseDate(b) - parseDate(a));
     return objectsCopy;
 }
+


### PR DESCRIPTION
#### What does this PR do?
Addresses [issue 14](https://github.com/codefordenver/cdphe-accessible-covid19/issues/14) and [issue 17](https://github.com/codefordenver/cdphe-accessible-covid19/issues/17)

Formats data in `StatsCard` component so that
1. Integers and decimals are comma separated.
2. Decimals are truncated to 2 decimal places.
3. NaNs and movements that will always be 0 or don't make sense for some other reason are hidden.
4. Aliases are used for abbreviated field names.

Changes the color of the movement statistic depending on context. It made more sense to me that an increase in deaths should be colored red, whereas an increase in population or number of tests should be colored green.

Adds a button that toggles the offset in the diffs between daily and weekly.

#### Where should the reviewer start?
Most relevant code for data formatting is in the `StatsCard` component. Changes to utility methods are in `utilities.js`.

Changes to add the daily/weekly toggle are in the `App` and `Home` components.

#### How should this be manually tested?
Go to the home page and check the formatting
![Screen Shot 2021-01-14 at 9 42 34 PM](https://user-images.githubusercontent.com/20004072/104682266-82e24880-56b1-11eb-85fb-7ba4cbc1cd19.png)
Then click the "Daily/Weekly" button
![Screen Shot 2021-01-14 at 9 42 46 PM](https://user-images.githubusercontent.com/20004072/104682299-92619180-56b1-11eb-98f9-03ffa119a16f.png)



#### Any background context you want to provide?
#### What are the relevant tickets?
Addresses [issue 14](https://github.com/codefordenver/cdphe-accessible-covid19/issues/14) and [issue 17](https://github.com/codefordenver/cdphe-accessible-covid19/issues/17)
#### Questions:

