### PR TITLE
add second button to toggle daily/weekly diffs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,16 @@
 .toggle-daily {
   order: -1;
   align-self: flex-start;
+  flex: 425px 1 1;
+  height: 40px;
+  display: flex;
+  flex-direction: row;
   margin-bottom: 20px;
+}
+
+.toggle-daily .daily, .toggle-daily .weekly {
   width: 80px;
+  margin-right: 10px;
+  padding: 0;
+  text-align: center;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -36,9 +36,9 @@ const App = () => {
   }, []);
 
   const handleToggleDaily = (event) => {
-    let target = event.target;
-    let targetIsDaily = target.classList.contains('daily');
-    let targetIsWeekly = target.classList.contains('weekly');
+    const target = event.target;
+    const targetIsDaily = target.classList.contains('daily');
+    const targetIsWeekly = target.classList.contains('weekly');
     if ((targetIsDaily && !isDaily) || (targetIsWeekly && isDaily)) {
       setIsDaily(!isDaily);
     }
@@ -49,16 +49,16 @@ const App = () => {
       <Sidebar />
       <section className='display'>
         <Route exact path='/'>
-          <div className="toggle-daily">
+          <div className="toggle-daily" role="button">
             <Button
-              className="toggle-daily daily"
+              className="daily"
               onClick={handleToggleDaily}
               color={isDaily ? "primary" : "secondary"}
             >
               Daily
             </Button>
             <Button
-              className="toggle-daily weekly"
+              className="weekly"
               onClick={handleToggleDaily}
               color={isDaily ? "secondary" : "primary"}
             >

--- a/src/App.js
+++ b/src/App.js
@@ -35,8 +35,13 @@ const App = () => {
       .catch((err) => console.log(err));
   }, []);
 
-  const handleToggleSubmit = (event) => {
-    setIsDaily(!isDaily);
+  const handleToggleDaily = (event) => {
+    let target = event.target;
+    let targetIsDaily = target.classList.contains('daily');
+    let targetIsWeekly = target.classList.contains('weekly');
+    if ((targetIsDaily && !isDaily) || (targetIsWeekly && isDaily)) {
+      setIsDaily(!isDaily);
+    }
   }
 
   return (
@@ -44,13 +49,22 @@ const App = () => {
       <Sidebar />
       <section className='display'>
         <Route exact path='/'>
-          <Button
-            className="toggle-daily"
-            onClick={handleToggleSubmit}
-            color={isDaily ? "primary" : "secondary"}
-          >
-              {isDaily ? "Daily" : "Weekly"}
-          </Button>
+          <div className="toggle-daily">
+            <Button
+              className="toggle-daily daily"
+              onClick={handleToggleDaily}
+              color={isDaily ? "primary" : "secondary"}
+            >
+              Daily
+            </Button>
+            <Button
+              className="toggle-daily weekly"
+              onClick={handleToggleDaily}
+              color={isDaily ? "secondary" : "primary"}
+            >
+              Weekly
+            </Button>
+          </div>
           <Home current={data[0]} previous={data[offset]} movementType={movementType}/>
         </Route>
         <Route exact path='/daily-cases'>

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import "tabler-react/dist/Tabler.css";
 import React, { useEffect, useState } from "react";
 
 import { API_URL } from "./utils/constants";
-import { Button } from "tabler-react";
 import DailyStats from "./components/DailyStats/DailyStats";
 import { Home } from "./components/Home/Home";
 import { Route } from "react-router-dom";
@@ -15,8 +14,7 @@ const App = () => {
   const [data, setData] = useState([]);
   const [isDaily, setIsDaily] = useState(true);
   // diffs are weekly if isDaily is false
-  const offset = isDaily ? 1 : 7;
-  const movementType = isDaily ? "daily" : "weekly";
+
   const cleanData = (data) => {
     let newData = [];
     data.map((attr) => newData.push(...Object.values(attr)));
@@ -35,49 +33,28 @@ const App = () => {
       .catch((err) => console.log(err));
   }, []);
 
-  const handleToggleDaily = (event) => {
-    const target = event.target;
-    const targetIsDaily = target.classList.contains('daily');
-    const targetIsWeekly = target.classList.contains('weekly');
-    if ((targetIsDaily && !isDaily) || (targetIsWeekly && isDaily)) {
-      setIsDaily(!isDaily);
-    }
-  }
-
   return (
-    <section className='app'>
+    <section className="app">
       <Sidebar />
-      <section className='display'>
-        <Route exact path='/'>
-          <div className="toggle-daily" role="button">
-            <Button
-              className="daily"
-              onClick={handleToggleDaily}
-              color={isDaily ? "primary" : "secondary"}
-            >
-              Daily
-            </Button>
-            <Button
-              className="weekly"
-              onClick={handleToggleDaily}
-              color={isDaily ? "secondary" : "primary"}
-            >
-              Weekly
-            </Button>
-          </div>
-          <Home current={data[0]} previous={data[offset]} movementType={movementType}/>
+      <section className="display">
+        <Route exact path="/">
+          <Home
+            data={data.slice(0, 8)}
+            isDaily={isDaily}
+            toggleDaily={() => setIsDaily(!isDaily)}
+          />
         </Route>
-        <Route exact path='/daily-cases'>
-          <DailyStats data={data} type='Cases' yAccessor='Cases' />
+        <Route exact path="/daily-cases">
+          <DailyStats data={data} type="Cases" yAccessor="Cases" />
         </Route>
-        <Route exact path='/daily-hosp'>
-          <DailyStats data={data} type='Hospitalized' yAccessor='Hosp' />
+        <Route exact path="/daily-hosp">
+          <DailyStats data={data} type="Hospitalized" yAccessor="Hosp" />
         </Route>
-        <Route exact path='/daily-deaths'>
-          <DailyStats data={data} type='Deaths' yAccessor='Deaths' />
+        <Route exact path="/daily-deaths">
+          <DailyStats data={data} type="Deaths" yAccessor="Deaths" />
         </Route>
-        <Route exact path='/daily-tested'>
-          <DailyStats data={data} type='Tested' yAccessor='Tested' />
+        <Route exact path="/daily-tested">
+          <DailyStats data={data} type="Tested" yAccessor="Tested" />
         </Route>
       </section>
     </section>

--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,6 @@ import { sortObjectsByDescendingDate } from "./utils/utilities";
 
 const App = () => {
   const [data, setData] = useState([]);
-  const [isDaily, setIsDaily] = useState(true);
-  // diffs are weekly if isDaily is false
 
   const cleanData = (data) => {
     let newData = [];
@@ -40,8 +38,6 @@ const App = () => {
         <Route exact path="/">
           <Home
             data={data.slice(0, 8)}
-            isDaily={isDaily}
-            toggleDaily={() => setIsDaily(!isDaily)}
           />
         </Route>
         <Route exact path="/daily-cases">

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,6 +1,7 @@
+import React, { useState } from "react";
+
 import { Button } from "tabler-react";
 import { Grid } from "tabler-react";
-import React from "react";
 import { StatsCard } from "./StatsCard";
 
 const GridContainer = (props) => (
@@ -9,19 +10,16 @@ const GridContainer = (props) => (
   </Grid.Col>
 );
 
-export const Home = ({ data, isDaily, toggleDaily }) => {
+export const Home = ({ data }) => {
+  const [isDaily, setIsDaily] = useState(true);
+  // diffs are weekly if isDaily is false
+
   const current = data[0];
   const previous = isDaily ? data[1] : data[7];
 
-  const handleClickDaily = (e) => {
-    if (!isDaily) {
-      toggleDaily();
-    }
-  };
-
-  const handleClickWeekly = (e) => {
-    if (isDaily) {
-      toggleDaily();
+  const handleToggleDaily = (dailyButton) => {
+    if ((dailyButton && !isDaily) || (!dailyButton && isDaily)) {
+      setIsDaily(!isDaily);
     }
   };
 
@@ -30,14 +28,14 @@ export const Home = ({ data, isDaily, toggleDaily }) => {
       <div className="toggle-daily" role="button">
         <Button
           className="daily"
-          onClick={handleClickDaily}
+          onClick={(e) => handleToggleDaily(true)}
           color={isDaily ? "primary" : "secondary"}
         >
           Daily
         </Button>
         <Button
           className="weekly"
-          onClick={handleClickWeekly}
+          onClick={(e) => handleToggleDaily(false)}
           color={isDaily ? "secondary" : "primary"}
         >
           Weekly

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,3 +1,4 @@
+import { Button } from "tabler-react";
 import { Grid } from "tabler-react";
 import React from "react";
 import { StatsCard } from "./StatsCard";
@@ -8,18 +9,48 @@ const GridContainer = (props) => (
   </Grid.Col>
 );
 
-export const Home = (props) => {
-  const { current, previous, movementType } = props;
+export const Home = ({ data, isDaily, toggleDaily }) => {
+  const current = data[0];
+  const previous = isDaily ? data[1] : data[7];
+
+  const handleClickDaily = (e) => {
+    if (!isDaily) {
+      toggleDaily();
+    }
+  };
+
+  const handleClickWeekly = (e) => {
+    if (isDaily) {
+      toggleDaily();
+    }
+  };
 
   return (
     <div>
+      <div className="toggle-daily" role="button">
+        <Button
+          className="daily"
+          onClick={handleClickDaily}
+          color={isDaily ? "primary" : "secondary"}
+        >
+          Daily
+        </Button>
+        <Button
+          className="weekly"
+          onClick={handleClickWeekly}
+          color={isDaily ? "secondary" : "primary"}
+        >
+          Weekly
+        </Button>
+      </div>
+
       {current && previous && (
         <Grid.Row cards deck>
           {Object.keys(current).map((key) => (
             <GridContainer>
               <StatsCard
                 movement={current[key] - previous[key]}
-                movementType={movementType}
+                movementType={isDaily ? "daily" : "weekly"}
                 total={current[key]}
                 label={key}
               />


### PR DESCRIPTION
#### What does this PR do?
Addresses [issue 17](https://github.com/codefordenver/cdphe-accessible-covid19/issues/17)

Splits the single button that toggles daily and weekly diffs on the daily snapshot page into two buttons.

#### Where should the reviewer start?
All changes are in the `App` component.
#### How should this be manually tested?
Try clicking back and forth between the two buttons. Also check that clicking the active button does not change the state of the app.
<img width="1131" alt="Screen Shot 2021-01-17 at 7 29 35 AM" src="https://user-images.githubusercontent.com/20004072/104846080-ef1da180-5895-11eb-8f67-6b7235930740.png">
<img width="1124" alt="Screen Shot 2021-01-17 at 7 29 48 AM" src="https://user-images.githubusercontent.com/20004072/104846086-f80e7300-5895-11eb-8af1-c82f85c91483.png">

#### Any background context you want to provide?
#### What are the relevant tickets?
Addresses [issue 17](https://github.com/codefordenver/cdphe-accessible-covid19/issues/17)
#### Questions:
